### PR TITLE
Fix sensor payload padding by packing sensor_data_t

### DIFF
--- a/include/schc_demo_app/services/sensor_service.h
+++ b/include/schc_demo_app/services/sensor_service.h
@@ -5,7 +5,7 @@
 // responsible for waking up
 // "performs" data sensing when woke up
 
-typedef struct {
+typedef struct __attribute__((packed)) {
     float temp;
     float pH;
     uint8_t bat;


### PR DESCRIPTION
 last 3 bytes being always zero were caused by compiler-added padding in sensor_data_t (float + float + uint8_t → 3 bytes padding) so this PR packs sensor_data_t removes the padding bytes, without changing SCHC rules or L2 logic.
when i tried it it worked without taking more time 
